### PR TITLE
chore: remove provider and region from example configs

### DIFF
--- a/1-getting-started/1-first-cortex-deployment/cerebrium.toml
+++ b/1-getting-started/1-first-cortex-deployment/cerebrium.toml
@@ -10,8 +10,6 @@ cpu = 2
 memory = 8.0
 compute = "AMPERE_A10"
 gpu_count = 1
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/1-getting-started/2-using-cerebrium-secrets/cerebrium.toml
+++ b/1-getting-started/2-using-cerebrium-secrets/cerebrium.toml
@@ -11,8 +11,6 @@ cpu = 3
 memory = 14.0
 compute = "AMPERE_A10"
 gpu_count = 1
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/1-getting-started/3-cpu-only/cerebrium.toml
+++ b/1-getting-started/3-cpu-only/cerebrium.toml
@@ -10,8 +10,6 @@ cpu = 2
 memory = 8.0
 compute = "CPU"
 gpu_count = 0
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/11-python-apps/3-asgi-graceful-shutdown/cerebrium.toml
+++ b/11-python-apps/3-asgi-graceful-shutdown/cerebrium.toml
@@ -8,8 +8,6 @@ cpu = 1
 memory = 1.0
 compute = "CPU"
 gpu_count = 0
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/14-embeddings/1-high-throughput/cerebrium.toml
+++ b/14-embeddings/1-high-throughput/cerebrium.toml
@@ -10,7 +10,6 @@ exclude = ['.*']
 cpu = 6.0
 memory = 12.0
 compute = "AMPERE_A10"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/2-advanced-concepts/1-faster-inference-with-vllm/cerebrium.toml
+++ b/2-advanced-concepts/1-faster-inference-with-vllm/cerebrium.toml
@@ -13,8 +13,6 @@ cpu = 8
 memory = 20.0
 compute = "AMPERE_A10"
 gpu_count = 1
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/2-advanced-concepts/2-inferentia/plain/cerebrium.toml
+++ b/2-advanced-concepts/2-inferentia/plain/cerebrium.toml
@@ -14,8 +14,6 @@ shell_commands = [
 ]
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "INF2"
 cpu = 6
 memory = 120.0

--- a/2-advanced-concepts/2-inferentia/vllm/cerebrium.toml
+++ b/2-advanced-concepts/2-inferentia/vllm/cerebrium.toml
@@ -18,8 +18,6 @@ shell_commands = [
 ]
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "INF2"
 cpu = 6
 memory = 60.0

--- a/2-advanced-concepts/3-loading-model-weights-faster/cerebrium.toml
+++ b/2-advanced-concepts/3-loading-model-weights-faster/cerebrium.toml
@@ -11,8 +11,6 @@ cpu = 4
 memory = 30.0
 compute = "AMPERE_A10"
 gpu_count = 1
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/2-advanced-concepts/4-multi-gpu-inference/cerebrium.toml
+++ b/2-advanced-concepts/4-multi-gpu-inference/cerebrium.toml
@@ -10,8 +10,6 @@ cpu = 4
 memory = 30.0
 compute = "AMPERE_A10"
 gpu_count = 4
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/2-advanced-concepts/5-dockerfile/cerebrium.toml
+++ b/2-advanced-concepts/5-dockerfile/cerebrium.toml
@@ -10,8 +10,6 @@ cpu = 1
 memory = 1.0
 compute = "CPU"
 gpu_count = 0
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.runtime.custom]
 port = 8192

--- a/3-endpoints/1-websockets/cerebrium.toml
+++ b/3-endpoints/1-websockets/cerebrium.toml
@@ -15,8 +15,6 @@ cpu = 2
 memory = 8.0
 compute = "CPU"
 gpu_count = 1
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/3-endpoints/2-simple-streaming/cerebrium.toml
+++ b/3-endpoints/2-simple-streaming/cerebrium.toml
@@ -10,8 +10,6 @@ cpu = 2
 memory = 2.0
 compute = "CPU"
 gpu_count = 1
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/4-integrations/1-langchain-QA/cerebrium.toml
+++ b/4-integrations/1-langchain-QA/cerebrium.toml
@@ -10,8 +10,6 @@ cpu = 4
 memory = 14.0
 compute = "AMPERE_A10"
 gpu_count = 1
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/4-integrations/2-tool-calling-langsmith/cerebrium.toml
+++ b/4-integrations/2-tool-calling-langsmith/cerebrium.toml
@@ -9,8 +9,6 @@ include = ["./*", "main.py", "cal.py", "cerebrium.toml"]
 exclude = ["./example_exclude", "langchain/"]
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "AMPERE_A10"
 cpu = 3
 memory = 12.0

--- a/5-large-language-models/2-streaming-endpoint/cerebrium.toml
+++ b/5-large-language-models/2-streaming-endpoint/cerebrium.toml
@@ -11,8 +11,6 @@ cpu = 4
 memory = 14.0
 compute = "AMPERE_A10"
 gpu_count = 1
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/5-large-language-models/3-winston/cerebrium.toml
+++ b/5-large-language-models/3-winston/cerebrium.toml
@@ -11,8 +11,6 @@ cpu = 4
 memory = 90.0
 compute = "AMPERE_A10"
 gpu_count = 1
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/5-large-language-models/5-inferentia-tranium/cerebrium.toml
+++ b/5-large-language-models/5-inferentia-tranium/cerebrium.toml
@@ -11,8 +11,6 @@ pre_build_commands = [
 ]
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "TRN1"
 cpu = 42
 memory = 330.0

--- a/5-large-language-models/8-faster-inference-with-triton-tensorrt/cerebrium.toml
+++ b/5-large-language-models/8-faster-inference-with-triton-tensorrt/cerebrium.toml
@@ -11,8 +11,6 @@ cpu = 4.0
 memory = 40.0
 compute = "AMPERE_A10"
 gpu_count = 1
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 1        

--- a/6-voice/1-whisper-transcription/cerebrium.toml
+++ b/6-voice/1-whisper-transcription/cerebrium.toml
@@ -10,8 +10,6 @@ cpu = 4
 memory = 14.0
 compute = "AMPERE_A10"
 gpu_count = 1
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/6-voice/12-realtime-livekit/deepgram/cerebrium.toml
+++ b/6-voice/12-realtime-livekit/deepgram/cerebrium.toml
@@ -6,7 +6,6 @@ disable_auth = true
 
 [cerebrium.hardware]
 cpu = 4
-region = "us-east-1"
 memory = 32
 compute = "AMPERE_A10"
 gpu_count = 1

--- a/6-voice/15-paypal-mcp-agent/pipecat_agent/cerebrium.toml
+++ b/6-voice/15-paypal-mcp-agent/pipecat_agent/cerebrium.toml
@@ -9,8 +9,6 @@ include = ["./*", "main.py", "cerebrium.toml"]
 exclude = ["./example_exclude"]
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "CPU"
 cpu = 6
 memory = 14.0

--- a/6-voice/17-orpheus/orpheus-fastapi/README_CEREBRIUM.md
+++ b/6-voice/17-orpheus/orpheus-fastapi/README_CEREBRIUM.md
@@ -16,8 +16,6 @@ exclude = ['.*']
 cpu = 4.0
 memory = 8.0
 compute = "CPU"
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/6-voice/17-orpheus/orpheus-fastapi/cerebrium.toml
+++ b/6-voice/17-orpheus/orpheus-fastapi/cerebrium.toml
@@ -10,8 +10,6 @@ exclude = ['.*']
 cpu = 4.0
 memory = 6.0
 compute = "CPU"
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/6-voice/17-orpheus/orpheus-server/cerebrium.toml
+++ b/6-voice/17-orpheus/orpheus-server/cerebrium.toml
@@ -10,8 +10,6 @@ exclude = ['.*']
 cpu = 6.0
 memory = 12.0
 compute = "ADA_L40"
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 1

--- a/6-voice/17.1-orpheus-simple/cerebrium.toml
+++ b/6-voice/17.1-orpheus-simple/cerebrium.toml
@@ -11,7 +11,6 @@ pre_build_commands = ["apt update && apt install -y git", "git clone https://git
 cpu = 12.0
 memory = 12.0
 compute = "HOPPER_H100"
-provider = "crusoe"
 
 [cerebrium.scaling]
 min_replicas = 1

--- a/6-voice/18-chatterbox-tts/cerebrium.toml
+++ b/6-voice/18-chatterbox-tts/cerebrium.toml
@@ -10,7 +10,6 @@ exclude = ['.*']
 cpu = 4.0
 memory = 12.0
 compute = "AMPERE_A10"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/6-voice/2-realtime-voice-agent/deepgram/cerebrium.toml
+++ b/6-voice/2-realtime-voice-agent/deepgram/cerebrium.toml
@@ -6,7 +6,6 @@ disable_auth = true
 
 [cerebrium.hardware]
 cpu = 4
-region = "us-east-1"
 memory = 32
 compute = "AMPERE_A10"
 gpu_count = 1

--- a/6-voice/2-realtime-voice-agent/pipecat-agent/cerebrium.toml
+++ b/6-voice/2-realtime-voice-agent/pipecat-agent/cerebrium.toml
@@ -9,8 +9,6 @@ include = ["./*", "main.py", "cerebrium.toml"]
 exclude = ["./example_exclude"]
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "CPU"
 cpu = 6
 memory = 18.0

--- a/6-voice/3-voice-rag-agent/cerebrium.toml
+++ b/6-voice/3-voice-rag-agent/cerebrium.toml
@@ -12,8 +12,6 @@ cpu = 3
 memory = 14.0
 compute = "AMPERE_A10"
 gpu_count = 1
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/6-voice/4-twilio-voice-agent/cerebrium.toml
+++ b/6-voice/4-twilio-voice-agent/cerebrium.toml
@@ -6,8 +6,6 @@ exclude = ["./example_exclude"]
 disable_auth = true
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "CPU"
 cpu = 10
 memory = 8.0

--- a/6-voice/6-openai-realtime-api-comparison/cerebrium.toml
+++ b/6-voice/6-openai-realtime-api-comparison/cerebrium.toml
@@ -7,8 +7,6 @@ exclude = ["./example_exclude"]
 shell_commands = ["pip install git+https://github.com/pipecat-ai/pipecat.git@khk/openai-realtime-beta#egg=pipecat-ai[silero,daily,openai,deepgram]"]
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "CPU"
 cpu = 2
 memory = 12.0

--- a/6-voice/8-multilingual-agent/cerebrium.toml
+++ b/6-voice/8-multilingual-agent/cerebrium.toml
@@ -6,8 +6,6 @@ exclude = ["./example_exclude"]
 disable_auth = true
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "AMPERE_A10"
 cpu = 2
 memory = 10.0

--- a/7-image-and-video/2-logo-controlnet/cerebrium.toml
+++ b/7-image-and-video/2-logo-controlnet/cerebrium.toml
@@ -10,8 +10,6 @@ cpu = 4
 memory = 14.0
 compute = "AMPERE_A10"
 gpu_count = 1
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/7-image-and-video/3-sdxl-refiner/cerebrium.toml
+++ b/7-image-and-video/3-sdxl-refiner/cerebrium.toml
@@ -10,8 +10,6 @@ exclude = ["./example_exclude"]
 docker_base_image_url = "debian:bookworm-slim"
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "AMPERE_A10"
 cpu = 2
 memory = 11.0

--- a/7-image-and-video/4-sdxl-lightning/cerebrium.toml
+++ b/7-image-and-video/4-sdxl-lightning/cerebrium.toml
@@ -9,8 +9,6 @@ exclude = ["./example_exclude"]
 docker_base_image_url = "nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04"
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "AMPERE_A10"
 cpu = 2
 memory = 12.0

--- a/7-image-and-video/5-fast-stable-diffusion/cerebrium.toml
+++ b/7-image-and-video/5-fast-stable-diffusion/cerebrium.toml
@@ -10,8 +10,6 @@ docker_base_image_url = "nvidia/cuda:12.1.1-runtime-ubuntu22.04"
 shell_commands = ["export HF_HOME=/cortex/.cache/huggingface", "python3 -c \"import torch; from diffusers import StableDiffusionPipeline; StableDiffusionPipeline.from_pretrained('stabilityai/stable-diffusion-2-1', torch_dtype=torch.float16)\""]
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "AMPERE_A10"
 cpu = 2
 memory = 16.0

--- a/7-image-and-video/6-regular-stable-diffusion/cerebrium.toml
+++ b/7-image-and-video/6-regular-stable-diffusion/cerebrium.toml
@@ -9,8 +9,6 @@ exclude = ["./example_exclude"]
 docker_base_image_url = "nvidia/cuda:12.1.1-runtime-ubuntu22.04"
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "AMPERE_A10"
 cpu = 2
 memory = 16.0

--- a/7-image-and-video/7-faster-image-generation/cerebrium.toml
+++ b/7-image-and-video/7-faster-image-generation/cerebrium.toml
@@ -15,8 +15,6 @@ shell_commands = [
 ]
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "AMPERE_A10"
 cpu = 3
 memory = 16.0

--- a/8-application-demos/1-sales-trainer/cerebrium.toml
+++ b/8-application-demos/1-sales-trainer/cerebrium.toml
@@ -11,8 +11,6 @@ cpu = 2
 memory = 6.0
 compute = "CPU"
 gpu_count = 0
-provider = "aws"
-region = "us-east-1"
 
 [cerebrium.scaling]
 min_replicas = 0

--- a/8-migrations/1-cog-migration-sdxl/cerebrium.toml
+++ b/8-migrations/1-cog-migration-sdxl/cerebrium.toml
@@ -9,8 +9,6 @@ shell_commands = [
 ]
 
 [cerebrium.hardware]
-region = "us-east-1"
-provider = "aws"
 compute = "AMPERE_A10"
 cpu = 2
 memory = 12.0


### PR DESCRIPTION
## Summary
- Strip `provider` and `region` keys from all 40 example `cerebrium.toml` files
- Remove the same keys from one inline TOML snippet in `6-voice/17-orpheus/orpheus-fastapi/README_CEREBRIUM.md`

Part of the multi-region rollout: apps will distribute to all clusters by default (`regions=["*"]`), and `provider` is being removed from the public surface entirely. Examples should reflect the new defaults — minimal config, no pinning.

Removed values:
- `region`: 40× `us-east-1` (no other regions used)
- `provider`: 36× `aws`, 1× `crusoe` (`6-voice/17.1-orpheus-simple` — the only non-default in the repo)

## Test plan
- [ ] Verify no `cerebrium.toml` under `examples/` still contains `provider` or `region` at the top level
- [ ] Spot-check one or two examples still deploy successfully against the current backend (which treats omitted region as default `us-east-1`, so behavior is unchanged until backend Phase 1 lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)